### PR TITLE
Use mktemp -t tmp.XXXXXXXXXX to support running on OS X

### DIFF
--- a/priv/reup-watcher.sh
+++ b/priv/reup-watcher.sh
@@ -7,7 +7,7 @@ then
 fi
 # we touch this file, then ask find to find files modified more recently
 # two files are used to avoid a touch->(save .erl)->find race condition
-MARKER=$(mktemp)
+MARKER=$(mktemp -t tmp.XXXXXXXXXX)
 a=0
 b=1
 touch "${MARKER}.$a"


### PR DESCRIPTION
Running mktemp without any arguments on OS X causes an error message to
be returned. Adding the argument -t tmp.XXXXXXXXXX will support running
on OS X and Linux.

This is only tested on OS X and Ubuntu, and according to the man pages
on Ubuntu, the -t flag is deprecated, but doesn't seem to have any ill effect.
